### PR TITLE
Added filename to PhpParser\Error

### DIFF
--- a/src/Finder/ParsedPhpFileFinder.php
+++ b/src/Finder/ParsedPhpFileFinder.php
@@ -40,7 +40,14 @@ class ParsedPhpFileFinder extends Finder
             $file = PhpFileInfo::create($file);
 
             if (null !== $this->parser) {
-                $this->parser->parseFile($file);
+                try {
+                    $this->parser->parseFile($file);
+                } catch (\PhpParser\Error $ex) {
+                    $raw = $ex->getRawMessage() . ' in file ' . $ex->getFile();
+                    $ex->setRawMessage($raw);
+
+                    throw $ex;
+                }
             }
 
             $files->append($file);


### PR DESCRIPTION
Adds the file path to error messages coming from PhpParser\Error
This is a fix for https://github.com/sensiolabs-de/deprecation-detector/issues/10