### PR TITLE
Fixed PSR-4 violations

### DIFF
--- a/src/Tests/TypeGuessing/SymbolTable/Resolver/SymfonyResolverTest.php
+++ b/src/Tests/TypeGuessing/SymbolTable/Resolver/SymfonyResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\TypeGuessing\SymbolTable\Resolver;
+namespace SensioLabs\DeprecationDetector\Tests\TypeGuessing\SymbolTable\Resolver;
 
 use PhpParser\Node;
 use SensioLabs\DeprecationDetector\TypeGuessing\SymbolTable\Resolver\SymfonyResolver;

--- a/src/Tests/TypeGuessing/Symfony/ContainerReaderTest.php
+++ b/src/Tests/TypeGuessing/Symfony/ContainerReaderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\TypeGuessing\Symfony;
+namespace SensioLabs\DeprecationDetector\Tests\TypeGuessing\Symfony;
 
 use SensioLabs\DeprecationDetector\TypeGuessing\Symfony\ContainerReader;
 

--- a/src/Tests/Visitor/Usage/FindArgumentsTest.php
+++ b/src/Tests/Visitor/Usage/FindArgumentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SensioLabs\DeprecationDetector\Tests\Visitor\ViolationVisitor;
+namespace SensioLabs\DeprecationDetector\Tests\Visitor\Usage;
 
 use PhpParser\Lexer\Emulative;
 use PhpParser\NodeTraverser;

--- a/src/Tests/Visitor/Usage/FindClassesTest.php
+++ b/src/Tests/Visitor/Usage/FindClassesTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace SensioLabs\DeprecationDetector\Tests\Visitor\ViolationVisitor;
+namespace SensioLabs\DeprecationDetector\Tests\Visitor\Usage;
 
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\FileInfo\Usage\ClassUsage;
-use SensioLabs\DeprecationDetector\Tests\Visitor\Usage\FindTestCase;
 use SensioLabs\DeprecationDetector\Visitor\Usage\FindClasses;
 
 class FindClassesTest extends FindTestCase

--- a/src/Tests/Visitor/Usage/FindInterfacesTest.php
+++ b/src/Tests/Visitor/Usage/FindInterfacesTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace SensioLabs\DeprecationDetector\Tests\Visitor\ViolationVisitor;
+namespace SensioLabs\DeprecationDetector\Tests\Visitor\Usage;
 
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\FileInfo\Usage\InterfaceUsage;
-use SensioLabs\DeprecationDetector\Tests\Visitor\Usage\FindTestCase;
 use SensioLabs\DeprecationDetector\Visitor\Usage\FindInterfaces;
 
 class FindInterfacesTest extends FindTestCase

--- a/src/Tests/Visitor/Usage/FindStaticMethodCallsTest.php
+++ b/src/Tests/Visitor/Usage/FindStaticMethodCallsTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace SensioLabs\DeprecationDetector\Tests\Visitor\ViolationVisitor;
+namespace SensioLabs\DeprecationDetector\Tests\Visitor\Usage;
 
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\FileInfo\Usage\MethodUsage;
-use SensioLabs\DeprecationDetector\Tests\Visitor\Usage\FindTestCase;
 use SensioLabs\DeprecationDetector\Visitor\Usage\FindStaticMethodCalls;
 
 class FindStaticMethodCallsTest extends FindTestCase

--- a/src/Tests/Visitor/Usage/FindSuperTypesTest.php
+++ b/src/Tests/Visitor/Usage/FindSuperTypesTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace SensioLabs\DeprecationDetector\Tests\Visitor\ViolationVisitor;
+namespace SensioLabs\DeprecationDetector\Tests\Visitor\Usage;
 
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\FileInfo\Usage\SuperTypeUsage;
-use SensioLabs\DeprecationDetector\Tests\Visitor\Usage\FindTestCase;
 use SensioLabs\DeprecationDetector\Visitor\Usage\FindSuperTypes;
 
 class FindSuperTypesTest extends FindTestCase


### PR DESCRIPTION
In some of the tests, the declared namespace did not match the filesystem structure according to PSR-4.