### PR TITLE
Removed all usages of the short array syntax

### DIFF
--- a/src/Tests/Parser/DeprecationParserTest.php
+++ b/src/Tests/Parser/DeprecationParserTest.php
@@ -9,7 +9,7 @@ class DeprecationParserTest extends \PHPUnit_Framework_TestCase
 {
     public function testClassIsInitializable()
     {
-        $deprecationParser = new DeprecationParser([], $this->prophesize('PhpParser\NodeTraverser')->reveal());
+        $deprecationParser = new DeprecationParser(array(), $this->prophesize('PhpParser\NodeTraverser')->reveal());
 
         $this->assertInstanceOf('SensioLabs\DeprecationDetector\Parser\DeprecationParser', $deprecationParser);
     }
@@ -22,7 +22,7 @@ class DeprecationParserTest extends \PHPUnit_Framework_TestCase
         $baseTraverser = $this->prophesize('PhpParser\NodeTraverser');
         $baseTraverser->addVisitor($visitor)->shouldBeCalled();
 
-        $deprecationParser = new DeprecationParser([], $baseTraverser->reveal());
+        $deprecationParser = new DeprecationParser(array(), $baseTraverser->reveal());
         $deprecationParser->addDeprecationVisitor($visitor);
     }
 

--- a/src/Tests/Parser/UsageParserTest.php
+++ b/src/Tests/Parser/UsageParserTest.php
@@ -24,8 +24,8 @@ class UsageParserTest extends \PHPUnit_Framework_TestCase
         $violationTraverser->addVisitor($violationVisitor)->shouldBeCalled();
 
         $deprecationParser = new UsageParser(
-            [$staticAnalysisVisitor],
-            [$violationVisitor],
+            array($staticAnalysisVisitor),
+            array($violationVisitor),
             $baseTraverser->reveal(),
             $staticAnalysisTraverser->reveal(),
             $violationTraverser->reveal()
@@ -45,17 +45,17 @@ class UsageParserTest extends \PHPUnit_Framework_TestCase
             ->reveal();
 
         $baseTraverser = $this->prophesize('PhpParser\NodeTraverser');
-        $baseTraverser->traverse([])->willReturn([])->shouldBeCalled();
+        $baseTraverser->traverse(array())->willReturn(array())->shouldBeCalled();
         $staticAnalysisTraverser = $this->prophesize('PhpParser\NodeTraverser');
-        $staticAnalysisTraverser->traverse([])->willReturn([])->shouldBeCalled();
+        $staticAnalysisTraverser->traverse(array())->willReturn(array())->shouldBeCalled();
 
         $violationTraverser = $this->prophesize('PhpParser\NodeTraverser');
         $violationTraverser->addVisitor($violationVisitor)->shouldBeCalled();
-        $violationTraverser->traverse([])->shouldBeCalled();
+        $violationTraverser->traverse(array())->shouldBeCalled();
 
         $deprecationParser = new UsageParser(
-            [],
-            [$violationVisitor],
+            array(),
+            array($violationVisitor),
             $baseTraverser->reveal(),
             $staticAnalysisTraverser->reveal(),
             $violationTraverser->reveal()

--- a/src/Tests/RuleSet/RuleSetTest.php
+++ b/src/Tests/RuleSet/RuleSetTest.php
@@ -28,7 +28,7 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     public function testClassDeprecations()
     {
         $classDeprecation = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\ClassDeprecation');
-        $classDeprecations = ['class' => $classDeprecation->reveal()];
+        $classDeprecations = array('class' => $classDeprecation->reveal());
         $ruleSet = new RuleSet($classDeprecations);
 
         $this->assertSame($classDeprecations, $ruleSet->classDeprecations());
@@ -37,7 +37,7 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     public function testHasClass()
     {
         $classDeprecation = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\ClassDeprecation');
-        $classDeprecations = ['class' => $classDeprecation->reveal()];
+        $classDeprecations = array('class' => $classDeprecation->reveal());
 
         $ruleSet = new RuleSet($classDeprecations);
         $this->assertTrue($ruleSet->hasClass('class'));
@@ -47,7 +47,7 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     public function testGetClass()
     {
         $classDeprecation = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\ClassDeprecation');
-        $classDeprecations = ['class' => $classDeprecation->reveal()];
+        $classDeprecations = array('class' => $classDeprecation->reveal());
 
         $ruleSet = new RuleSet($classDeprecations);
         $this->assertSame($classDeprecation->reveal(), $ruleSet->getClass('class'));
@@ -58,9 +58,9 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     {
         $interfaceDeprecation = $this
             ->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\InterfaceDeprecation');
-        $interfaceDeprecations = ['interface' => $interfaceDeprecation->reveal()];
+        $interfaceDeprecations = array('interface' => $interfaceDeprecation->reveal());
 
-        $ruleSet = new RuleSet([], $interfaceDeprecations);
+        $ruleSet = new RuleSet(array(), $interfaceDeprecations);
         $this->assertSame($interfaceDeprecations, $ruleSet->interfaceDeprecations());
     }
 
@@ -68,9 +68,9 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     {
         $interfaceDeprecation = $this
             ->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\InterfaceDeprecation');
-        $interfaceDeprecations = ['interface' => $interfaceDeprecation->reveal()];
+        $interfaceDeprecations = array('interface' => $interfaceDeprecation->reveal());
 
-        $ruleSet = new RuleSet([], $interfaceDeprecations);
+        $ruleSet = new RuleSet(array(), $interfaceDeprecations);
         $this->assertTrue($ruleSet->hasInterface('interface'));
         $this->assertFalse($ruleSet->hasInterface('someOtherInterface'));
     }
@@ -79,9 +79,9 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     {
         $interfaceDeprecation = $this
             ->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\InterfaceDeprecation');
-        $interfaceDeprecations = ['interface' => $interfaceDeprecation->reveal()];
+        $interfaceDeprecations = array('interface' => $interfaceDeprecation->reveal());
 
-        $ruleSet = new RuleSet([], $interfaceDeprecations);
+        $ruleSet = new RuleSet(array(), $interfaceDeprecations);
         $this->assertSame($interfaceDeprecation->reveal(), $ruleSet->getInterface('interface'));
         $this->assertNull($ruleSet->getInterface('someOtherInterface'));
     }
@@ -89,8 +89,8 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     public function testMethodDeprecations()
     {
         $methodDeprecation = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\MethodDeprecation');
-        $methodDeprecations = ['class' => [$methodDeprecation->reveal()]];
-        $ruleSet = new RuleSet([], [], $methodDeprecations);
+        $methodDeprecations = array('class' => array($methodDeprecation->reveal()));
+        $ruleSet = new RuleSet(array(), array(), $methodDeprecations);
 
         $this->assertSame($methodDeprecations, $ruleSet->methodDeprecations());
     }
@@ -98,8 +98,8 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     public function testHasMethod()
     {
         $methodDeprecation = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\MethodDeprecation');
-        $methodDeprecations = ['class' => ['method' => $methodDeprecation->reveal()]];
-        $ruleSet = new RuleSet([], [], $methodDeprecations);
+        $methodDeprecations = array('class' => array('method' => $methodDeprecation->reveal()));
+        $ruleSet = new RuleSet(array(), array(), $methodDeprecations);
 
         $this->assertTrue($ruleSet->hasMethod('method', 'class'));
         $this->assertFalse($ruleSet->hasMethod('someOtherMethod', 'class'));
@@ -108,8 +108,8 @@ class RuleSetTest extends \PHPUnit_Framework_TestCase
     public function testGetMethod()
     {
         $methodDeprecation = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\MethodDeprecation');
-        $methodDeprecations = ['class' => ['method' => $methodDeprecation->reveal()]];
-        $ruleSet = new RuleSet([], [], $methodDeprecations);
+        $methodDeprecations = array('class' => array('method' => $methodDeprecation->reveal()));
+        $ruleSet = new RuleSet(array(), array(), $methodDeprecations);
 
         $this->assertSame($methodDeprecation->reveal(), $ruleSet->getMethod('method', 'class'));
         $this->assertNull($ruleSet->getMethod('someOtherMethod', 'class'));

--- a/src/Tests/TypeGuessing/ConstructorResolver/ConstructorResolverTest.php
+++ b/src/Tests/TypeGuessing/ConstructorResolver/ConstructorResolverTest.php
@@ -25,8 +25,8 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolveConstructorAndAddVisitors()
     {
         $classMethod = new ClassMethod('__construct');
-        $classMethod->stmts = [$node = new Variable('x')];
-        $classMethods = [$classMethod];
+        $classMethod->stmts = array($node = new Variable('x'));
+        $classMethods = array($classMethod);
         $classNode = new Class_('SomeClass');
         $classNode->stmts = $classMethods;
 
@@ -49,7 +49,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     {
         $classMethod = new ClassMethod('someMethod');
         $classNode = new Class_('SomeClass');
-        $classNode->stmts = [$classMethod];
+        $classNode->stmts = array($classMethod);
 
         $table = $this->prophesize('SensioLabs\DeprecationDetector\TypeGuessing\SymbolTable\SymbolTable');
         $table->enterScope(new TableScope(TableScope::CLASS_METHOD_SCOPE))->shouldNotBeCalled();

--- a/src/Tests/Violation/ViolationChecker/ComposedViolationCheckerTest.php
+++ b/src/Tests/Violation/ViolationChecker/ComposedViolationCheckerTest.php
@@ -55,6 +55,6 @@ class ComposedViolationCheckerTest extends \PHPUnit_Framework_TestCase
             $concreteChecker->reveal(),
         ));
 
-        $this->assertSame([], $checker->check($file));
+        $this->assertSame(array(), $checker->check($file));
     }
 }

--- a/src/Violation/Renderer/MessageHelper/MessageHelper.php
+++ b/src/Violation/Renderer/MessageHelper/MessageHelper.php
@@ -10,12 +10,7 @@ class MessageHelper
     /**
      * @var ViolationMessageInterface[]
      */
-    private $messages;
-
-    public function __construct()
-    {
-        $this->messages = [];
-    }
+    private $messages = array();
 
     /**
      * @param ViolationMessageInterface $message


### PR DESCRIPTION
We want this tool to be usable in a php 5.3 environment. Therefore, we unfortunately cannot make use of syntactic sugar introduced with php 5.4 and later.

This PR removes all occurrences of php's short array syntax `[]` and converts them to the old syntax `array()`.