### PR TITLE
exit code !=0 on

### DIFF
--- a/src/Console/Command/CheckCommand.php
+++ b/src/Console/Command/CheckCommand.php
@@ -133,7 +133,7 @@ EOF
         if (null === $ruleSet) {
             $output->writeln(sprintf('<error>check aborted - no rule set found for %s</error>', $ruleSetArg));
 
-            return -1;
+            return 1;
         }
 
         $lib = (is_dir($ruleSetArg) ? $ruleSetArg : realpath('vendor')); // TODO: not hard coded

--- a/src/Console/Command/CheckCommand.php
+++ b/src/Console/Command/CheckCommand.php
@@ -43,6 +43,7 @@ class CheckCommand extends Command
                     ),
                     new InputOption('no-cache', null, InputOption::VALUE_NONE, 'Disable rule set cache'),
                     new InputOption('cache-dir', null, InputOption::VALUE_REQUIRED, 'Cache directory', '.rules/'),
+                    new InputOption('fail', null, InputOption::VALUE_NONE, 'Fails, if any deprecation is detected'),
                 )
             )
             ->setDescription('Check for deprecated usage')
@@ -153,7 +154,7 @@ EOF
 
         $container['violation.renderer']->renderViolations($violations);
 
-        return 1;
+        return $input->getOption('fail') ? 1 : 0;
     }
 
     /**

--- a/src/Console/Command/CheckCommand.php
+++ b/src/Console/Command/CheckCommand.php
@@ -133,7 +133,7 @@ EOF
         if (null === $ruleSet) {
             $output->writeln(sprintf('<error>check aborted - no rule set found for %s</error>', $ruleSetArg));
 
-            return 0;
+            return -1;
         }
 
         $lib = (is_dir($ruleSetArg) ? $ruleSetArg : realpath('vendor')); // TODO: not hard coded
@@ -153,7 +153,7 @@ EOF
 
         $container['violation.renderer']->renderViolations($violations);
 
-        return 0;
+        return 1;
     }
 
     /**


### PR DESCRIPTION
To use the tool in CI, it is useful to have an exit-code on errors. So the build can break, if any deprecations were detected.