### PR TITLE
refactored separation/dependency injection of violation check

### DIFF
--- a/src/Console/Command/CheckCommand.php
+++ b/src/Console/Command/CheckCommand.php
@@ -3,13 +3,8 @@
 namespace SensioLabs\DeprecationDetector\Console\Command;
 
 use SensioLabs\DeprecationDetector\EventListener\ProgressListener;
-use SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder;
-use SensioLabs\DeprecationDetector\ProgressEvent;
 use SensioLabs\DeprecationDetector\RuleSet\Loader;
 use SensioLabs\DeprecationDetector\RuleSet\RuleSet;
-use SensioLabs\DeprecationDetector\Violation\Violation;
-use SensioLabs\DeprecationDetector\Violation\ViolationChecker\ComposedViolationChecker;
-use SensioLabs\DeprecationDetector\Violation\ViolationChecker;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -178,5 +173,4 @@ EOF
 
         return $loader->loadRuleSet($ruleSet);
     }
-
 }

--- a/src/Detector/ViolationDetector.php
+++ b/src/Detector/ViolationDetector.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Detector;
+
+use SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder;
+use SensioLabs\DeprecationDetector\ProgressEvent;
+use SensioLabs\DeprecationDetector\RuleSet\RuleSet;
+use SensioLabs\DeprecationDetector\Violation\Violation;
+use SensioLabs\DeprecationDetector\Violation\ViolationChecker\ViolationCheckerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ViolationDetector {
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+    /**
+     * @var ViolationCheckerInterface
+     */
+    private $violationChecker;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, ViolationCheckerInterface $violationChecker)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->violationChecker = $violationChecker;
+    }
+
+    /**
+     * @param RuleSet             $ruleSet
+     * @param ParsedPhpFileFinder $files
+     *
+     * @return Violation[]
+     */
+    public function getViolations(RuleSet $ruleSet, ParsedPhpFileFinder $files)
+    {
+        $total = count($files);
+        $this->eventDispatcher->dispatch(
+            ProgressEvent::CHECKER,
+            new ProgressEvent(0, $total)
+        );
+
+        $result = array();
+        foreach ($files as $i => $file) {
+            $result = array_merge($result, $this->violationChecker->check($file, $ruleSet));
+
+            $this->eventDispatcher->dispatch(
+                ProgressEvent::CHECKER,
+                new ProgressEvent(++$i, $total)
+            );
+        }
+
+        return $result;
+    }
+
+}

--- a/src/Detector/ViolationDetector.php
+++ b/src/Detector/ViolationDetector.php
@@ -9,8 +9,8 @@ use SensioLabs\DeprecationDetector\Violation\Violation;
 use SensioLabs\DeprecationDetector\Violation\ViolationChecker\ViolationCheckerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ViolationDetector {
-
+class ViolationDetector
+{
     /**
      * @var EventDispatcherInterface
      */
@@ -52,5 +52,4 @@ class ViolationDetector {
 
         return $result;
     }
-
 }

--- a/src/Finder/ParsedPhpFileFinder.php
+++ b/src/Finder/ParsedPhpFileFinder.php
@@ -43,7 +43,7 @@ class ParsedPhpFileFinder extends Finder
                 try {
                     $this->parser->parseFile($file);
                 } catch (\PhpParser\Error $ex) {
-                    $raw = $ex->getRawMessage() . ' in file ' . $ex->getFile();
+                    $raw = $ex->getRawMessage().' in file '.$ex->getFile();
                     $ex->setRawMessage($raw);
 
                     throw $ex;

--- a/src/Tests/Violation/ViolationChecker/ClassViolationCheckerTest.php
+++ b/src/Tests/Violation/ViolationChecker/ClassViolationCheckerTest.php
@@ -47,10 +47,10 @@ class ClassViolationCheckerTest extends \PHPUnit_Framework_TestCase
 
         $ruleSet->getClass('deprecatedClass')->willReturn($classDeprecation->reveal());
 
-        $checker = new ClassViolationChecker($ruleSet->reveal());
+        $checker = new ClassViolationChecker();
 
         $this->assertEquals(array(
             new Violation($deprecatedClassUsage, $collection, $deprecationComment),
-        ), $checker->check($collection));
+        ), $checker->check($collection, $ruleSet->reveal()));
     }
 }

--- a/src/Tests/Violation/ViolationChecker/ComposedViolationCheckerTest.php
+++ b/src/Tests/Violation/ViolationChecker/ComposedViolationCheckerTest.php
@@ -21,17 +21,19 @@ class ComposedViolationCheckerTest extends \PHPUnit_Framework_TestCase
         $file = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo');
         $file = $file->reveal();
 
+        $ruleSet = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\RuleSet');
+
         $concreteChecker = $this
             ->prophesize('SensioLabs\DeprecationDetector\Violation\ViolationChecker\ViolationCheckerInterface');
-        $concreteChecker->check($file)->willReturn(array())->shouldBeCalled();
+        $concreteChecker->check($file, $ruleSet)->willReturn(array())->shouldBeCalled();
 
         $concreteCheckerTwo = $this
             ->prophesize('SensioLabs\DeprecationDetector\Violation\ViolationChecker\ViolationCheckerInterface');
-        $concreteCheckerTwo->check($file)->willReturn(array())->shouldBeCalled();
+        $concreteCheckerTwo->check($file, $ruleSet)->willReturn(array())->shouldBeCalled();
 
         $concreteCheckerThree = $this
             ->prophesize('SensioLabs\DeprecationDetector\Violation\ViolationChecker\ViolationCheckerInterface');
-        $concreteCheckerThree->check($file)->willReturn(array())->shouldBeCalled();
+        $concreteCheckerThree->check($file, $ruleSet)->willReturn(array())->shouldBeCalled();
 
         $checker = new ComposedViolationChecker(array(
             $concreteChecker->reveal(),
@@ -39,7 +41,7 @@ class ComposedViolationCheckerTest extends \PHPUnit_Framework_TestCase
             $concreteCheckerThree->reveal(),
         ));
 
-        $checker->check($file);
+        $checker->check($file, $ruleSet->reveal());
     }
 
     public function testCheckReturnsArrayIfAnExceptionIsThrown()
@@ -47,14 +49,16 @@ class ComposedViolationCheckerTest extends \PHPUnit_Framework_TestCase
         $file = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo');
         $file = $file->reveal();
 
+        $ruleSet = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\RuleSet');
+
         $concreteChecker = $this
             ->prophesize('SensioLabs\DeprecationDetector\Violation\ViolationChecker\ViolationCheckerInterface');
-        $concreteChecker->check($file)->willThrow(new \Exception())->shouldBeCalled();
+        $concreteChecker->check($file, $ruleSet)->willThrow(new \Exception())->shouldBeCalled();
 
         $checker = new ComposedViolationChecker(array(
             $concreteChecker->reveal(),
         ));
 
-        $this->assertSame(array(), $checker->check($file));
+        $this->assertSame(array(), $checker->check($file, $ruleSet->reveal()));
     }
 }

--- a/src/Tests/Violation/ViolationChecker/InterfaceViolationCheckerTest.php
+++ b/src/Tests/Violation/ViolationChecker/InterfaceViolationCheckerTest.php
@@ -40,21 +40,21 @@ class InterfaceViolationCheckerTest extends \PHPUnit_Framework_TestCase
             $deprecatedInterfaceUsage,
             ))
         );
-            $collection = $collection->reveal();
+        $collection = $collection->reveal();
 
-            $ruleSet->hasInterface('interface')->willReturn(false);
-            $ruleSet->hasInterface('deprecatedInterface')->willReturn(true);
+        $ruleSet->hasInterface('interface')->willReturn(false);
+        $ruleSet->hasInterface('deprecatedInterface')->willReturn(true);
 
-            $deprecationComment = 'comment';
-            $interfaceDeprecation = $this
+        $deprecationComment = 'comment';
+        $interfaceDeprecation = $this
                 ->prophesize('SensioLabs\DeprecationDetector\FileInfo\Deprecation\InterfaceDeprecation');
-            $interfaceDeprecation->comment()->willReturn($deprecationComment);
+        $interfaceDeprecation->comment()->willReturn($deprecationComment);
 
-            $ruleSet->getInterface('deprecatedInterface')->willReturn($interfaceDeprecation->reveal());
+        $ruleSet->getInterface('deprecatedInterface')->willReturn($interfaceDeprecation->reveal());
 
-            $checker = new InterfaceViolationChecker();
+        $checker = new InterfaceViolationChecker();
 
-            $this->assertEquals(array(
+        $this->assertEquals(array(
             new Violation($deprecatedInterfaceUsage, $collection, $deprecationComment),
             ), $checker->check($collection, $ruleSet->reveal()));
     }

--- a/src/Tests/Violation/ViolationChecker/InterfaceViolationCheckerTest.php
+++ b/src/Tests/Violation/ViolationChecker/InterfaceViolationCheckerTest.php
@@ -52,10 +52,10 @@ class InterfaceViolationCheckerTest extends \PHPUnit_Framework_TestCase
 
             $ruleSet->getInterface('deprecatedInterface')->willReturn($interfaceDeprecation->reveal());
 
-            $checker = new InterfaceViolationChecker($ruleSet->reveal());
+            $checker = new InterfaceViolationChecker();
 
             $this->assertEquals(array(
             new Violation($deprecatedInterfaceUsage, $collection, $deprecationComment),
-            ), $checker->check($collection));
+            ), $checker->check($collection, $ruleSet->reveal()));
     }
 }

--- a/src/Tests/Violation/ViolationChecker/MethodViolationCheckerTest.php
+++ b/src/Tests/Violation/ViolationChecker/MethodViolationCheckerTest.php
@@ -9,9 +9,8 @@ class MethodViolationCheckerTest extends \PHPUnit_Framework_TestCase
 {
     public function testClassIsInitializable()
     {
-        $ruleSet = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\RuleSet');
         $ancestorResolver = $this->prophesize('SensioLabs\DeprecationDetector\AncestorResolver');
-        $checker = new MethodViolationChecker($ruleSet->reveal(), $ancestorResolver->reveal());
+        $checker = new MethodViolationChecker($ancestorResolver->reveal());
 
         $this->assertInstanceOf(
             'SensioLabs\DeprecationDetector\Violation\ViolationChecker\MethodViolationChecker',
@@ -55,11 +54,11 @@ class MethodViolationCheckerTest extends \PHPUnit_Framework_TestCase
         $ancestorResolver = $this->prophesize('SensioLabs\DeprecationDetector\AncestorResolver');
         $ancestorResolver->getClassAncestors($phpFileInfo, 'class')->willReturn(array());
 
-        $checker = new MethodViolationChecker($ruleSet->reveal(), $ancestorResolver->reveal());
+        $checker = new MethodViolationChecker($ancestorResolver->reveal());
 
         $this->assertEquals(
             array(new Violation($deprecatedMethodUsage, $phpFileInfo, $deprecationComment)),
-            $checker->check($phpFileInfo)
+            $checker->check($phpFileInfo, $ruleSet->reveal())
         );
     }
 }

--- a/src/Tests/Violation/ViolationChecker/SuperTypeViolationCheckerTest.php
+++ b/src/Tests/Violation/ViolationChecker/SuperTypeViolationCheckerTest.php
@@ -49,10 +49,10 @@ class SuperTypeViolationCheckerTest extends \PHPUnit_Framework_TestCase
 
         $ruleSet->getClass('deprecatedClass')->willReturn($classDeprecation->reveal());
 
-        $checker = new SuperTypeViolationChecker($ruleSet->reveal());
+        $checker = new SuperTypeViolationChecker();
 
         $this->assertEquals(array(
             new Violation($deprecatedSuperTypeUsage, $collection, $deprecationComment),
-        ), $checker->check($collection));
+        ), $checker->check($collection, $ruleSet->reveal()));
     }
 }

--- a/src/Tests/Violation/ViolationChecker/TypeHintViolationCheckerTest.php
+++ b/src/Tests/Violation/ViolationChecker/TypeHintViolationCheckerTest.php
@@ -38,12 +38,12 @@ class TypeHintViolationCheckerTest extends \PHPUnit_Framework_TestCase
         $ruleSet->hasClass('TypeHint')->willReturn(true);
         $ruleSet->getClass('TypeHint')->willReturn($classDeprecation->reveal());
 
-        $checker = new TypeHintViolationChecker($ruleSet->reveal());
+        $checker = new TypeHintViolationChecker();
         $usage = new ClassUsage('TypeHint', 123);
 
         $this->assertEquals(array(
             new Violation($usage, $phpFileInfo, 'comment'),
-        ), $checker->check($phpFileInfo));
+        ), $checker->check($phpFileInfo, $ruleSet->reveal()));
     }
 
     public function testInterfaceTypeHintCheck()
@@ -66,11 +66,11 @@ class TypeHintViolationCheckerTest extends \PHPUnit_Framework_TestCase
         $ruleSet->hasInterface('TypeHint')->willReturn(true);
         $ruleSet->getInterface('TypeHint')->willReturn($interfaceDeprecation->reveal());
 
-        $checker = new TypeHintViolationChecker($ruleSet->reveal());
+        $checker = new TypeHintViolationChecker();
         $usage = new InterfaceUsage('TypeHint', '', 123);
 
         $this->assertEquals(array(
             new Violation($usage, $phpFileInfo, 'comment'),
-        ), $checker->check($phpFileInfo));
+        ), $checker->check($phpFileInfo, $ruleSet->reveal()));
     }
 }

--- a/src/TypeGuessing/SymbolTable/Resolver/SymfonyResolver.php
+++ b/src/TypeGuessing/SymbolTable/Resolver/SymfonyResolver.php
@@ -31,7 +31,7 @@ class SymfonyResolver implements ResolverInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function resolveVariableType(Node $node)
     {

--- a/src/TypeGuessing/Symfony/ContainerReader.php
+++ b/src/TypeGuessing/Symfony/ContainerReader.php
@@ -79,7 +79,7 @@ class ContainerReader
     {
         throw new \BadMethodCallException(
             'Unlike Symfony container SymfonyContainerReader is read only and just implements the '
-            . 'methods "has" and "get".'
+            .'methods "has" and "get".'
         );
     }
 }

--- a/src/Violation/ViolationChecker/ClassViolationChecker.php
+++ b/src/Violation/ViolationChecker/ClassViolationChecker.php
@@ -9,31 +9,18 @@ use SensioLabs\DeprecationDetector\Violation\Violation;
 class ClassViolationChecker implements ViolationCheckerInterface
 {
     /**
-     * @var RuleSet
-     */
-    private $ruleSet;
-
-    /**
-     * @param RuleSet $ruleSet
-     */
-    public function __construct(RuleSet $ruleSet)
-    {
-        $this->ruleSet = $ruleSet;
-    }
-
-    /**
      * {@inheritdoc}
      */
-    public function check(PhpFileInfo $phpFileInfo)
+    public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet)
     {
         $violations = array();
 
         foreach ($phpFileInfo->classUsages() as $classUsage) {
-            if ($this->ruleSet->hasClass($classUsage->name())) {
+            if ($ruleSet->hasClass($classUsage->name())) {
                 $violations[] = new Violation(
                     $classUsage,
                     $phpFileInfo,
-                    $this->ruleSet->getClass($classUsage->name())->comment()
+                    $ruleSet->getClass($classUsage->name())->comment()
                 );
             }
         }

--- a/src/Violation/ViolationChecker/ComposedViolationChecker.php
+++ b/src/Violation/ViolationChecker/ComposedViolationChecker.php
@@ -3,6 +3,7 @@
 namespace SensioLabs\DeprecationDetector\Violation\ViolationChecker;
 
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
+use SensioLabs\DeprecationDetector\RuleSet\RuleSet;
 
 class ComposedViolationChecker implements ViolationCheckerInterface
 {
@@ -22,11 +23,11 @@ class ComposedViolationChecker implements ViolationCheckerInterface
     /**
      * {@inheritdoc}
      */
-    public function check(PhpFileInfo $phpFileInfo)
+    public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet)
     {
-        $violations = array_map(function (ViolationCheckerInterface $checker) use ($phpFileInfo) {
+        $violations = array_map(function (ViolationCheckerInterface $checker) use ($phpFileInfo, $ruleSet) {
             try {
-                return $checker->check($phpFileInfo);
+                return $checker->check($phpFileInfo, $ruleSet);
             } catch (\Exception $e) {
                 # TODO.
                 return array();

--- a/src/Violation/ViolationChecker/InterfaceViolationChecker.php
+++ b/src/Violation/ViolationChecker/InterfaceViolationChecker.php
@@ -9,32 +9,19 @@ use SensioLabs\DeprecationDetector\Violation\Violation;
 class InterfaceViolationChecker implements ViolationCheckerInterface
 {
     /**
-     * @var RuleSet
-     */
-    private $ruleSet;
-
-    /**
-     * @param RuleSet $ruleSet
-     */
-    public function __construct(RuleSet $ruleSet)
-    {
-        $this->ruleSet = $ruleSet;
-    }
-
-    /**
      * {@inheritdoc}
      */
-    public function check(PhpFileInfo $phpFileInfo)
+    public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet)
     {
         $violations = array();
 
         foreach ($phpFileInfo->interfaceUsages() as $interfaceUsageGroup) {
             foreach ($interfaceUsageGroup as $interfaceUsage) {
-                if ($this->ruleSet->hasInterface($interfaceUsage->name())) {
+                if ($ruleSet->hasInterface($interfaceUsage->name())) {
                     $violations[] = new Violation(
                         $interfaceUsage,
                         $phpFileInfo,
-                        $this->ruleSet->getInterface($interfaceUsage->name())->comment()
+                        $ruleSet->getInterface($interfaceUsage->name())->comment()
                     );
                 }
             }

--- a/src/Violation/ViolationChecker/MethodDefinitionViolationChecker.php
+++ b/src/Violation/ViolationChecker/MethodDefinitionViolationChecker.php
@@ -10,11 +10,6 @@ use SensioLabs\DeprecationDetector\Violation\Violation;
 class MethodDefinitionViolationChecker implements ViolationCheckerInterface
 {
     /**
-     * @var RuleSet
-     */
-    protected $ruleSet;
-
-    /**
      * @var AncestorResolver
      */
     protected $ancestorResolver;
@@ -23,16 +18,15 @@ class MethodDefinitionViolationChecker implements ViolationCheckerInterface
      * @param RuleSet          $ruleSet
      * @param AncestorResolver $ancestorResolver
      */
-    public function __construct(RuleSet $ruleSet, AncestorResolver $ancestorResolver)
+    public function __construct(AncestorResolver $ancestorResolver)
     {
-        $this->ruleSet = $ruleSet;
         $this->ancestorResolver = $ancestorResolver;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function check(PhpFileInfo $phpFileInfo)
+    public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet)
     {
         $violations = array();
 
@@ -40,11 +34,11 @@ class MethodDefinitionViolationChecker implements ViolationCheckerInterface
             $ancestors = $this->ancestorResolver->getClassAncestors($phpFileInfo, $methodDefinition->parentName());
 
             foreach ($ancestors as $ancestor) {
-                if ($this->ruleSet->hasMethod($methodDefinition->name(), $ancestor)) {
+                if ($ruleSet->hasMethod($methodDefinition->name(), $ancestor)) {
                     $violations[] = new Violation(
                         $methodDefinition,
                         $phpFileInfo,
-                        $this->ruleSet->getMethod($methodDefinition->name(), $ancestor)->comment()
+                        $ruleSet->getMethod($methodDefinition->name(), $ancestor)->comment()
                     );
                 }
             }

--- a/src/Violation/ViolationChecker/MethodViolationChecker.php
+++ b/src/Violation/ViolationChecker/MethodViolationChecker.php
@@ -11,47 +11,40 @@ use SensioLabs\DeprecationDetector\Violation\Violation;
 class MethodViolationChecker implements ViolationCheckerInterface
 {
     /**
-     * @var RuleSet
-     */
-    protected $ruleSet;
-
-    /**
      * @var AncestorResolver
      */
     protected $ancestorResolver;
 
     /**
-     * @param RuleSet          $ruleSet
      * @param AncestorResolver $ancestorResolver
      */
-    public function __construct(RuleSet $ruleSet, AncestorResolver $ancestorResolver)
+    public function __construct(AncestorResolver $ancestorResolver)
     {
-        $this->ruleSet = $ruleSet;
         $this->ancestorResolver = $ancestorResolver;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function check(PhpFileInfo $phpFileInfo)
+    public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet)
     {
         $violations = array();
 
         foreach ($phpFileInfo->methodUsages() as $methodUsage) {
             $className = $methodUsage->className();
 
-            if ($this->ruleSet->hasMethod($methodUsage->name(), $className)) {
+            if ($ruleSet->hasMethod($methodUsage->name(), $className)) {
                 $violations[] = new Violation(
                     $methodUsage,
                     $phpFileInfo,
-                    $this->ruleSet->getMethod($methodUsage->name(), $className)->comment()
+                    $ruleSet->getMethod($methodUsage->name(), $className)->comment()
                 );
             }
 
             $ancestors = $this->ancestorResolver->getClassAncestors($phpFileInfo, $methodUsage->className());
 
             foreach ($ancestors as $ancestor) {
-                if ($this->ruleSet->hasMethod($methodUsage->name(), $ancestor)) {
+                if ($ruleSet->hasMethod($methodUsage->name(), $ancestor)) {
                     $violations[] = new Violation(
                         new MethodUsage(
                             $methodUsage->name(),
@@ -60,7 +53,7 @@ class MethodViolationChecker implements ViolationCheckerInterface
                             $methodUsage->isStatic()
                         ),
                         $phpFileInfo,
-                        $this->ruleSet->getMethod($methodUsage->name(), $ancestor)->comment()
+                        $ruleSet->getMethod($methodUsage->name(), $ancestor)->comment()
                     );
                 }
             }

--- a/src/Violation/ViolationChecker/SuperTypeViolationChecker.php
+++ b/src/Violation/ViolationChecker/SuperTypeViolationChecker.php
@@ -9,31 +9,18 @@ use SensioLabs\DeprecationDetector\Violation\Violation;
 class SuperTypeViolationChecker implements ViolationCheckerInterface
 {
     /**
-     * @var RuleSet
-     */
-    private $ruleSet;
-
-    /**
-     * @param RuleSet $ruleSet
-     */
-    public function __construct(RuleSet $ruleSet)
-    {
-        $this->ruleSet = $ruleSet;
-    }
-
-    /**
      * {@inheritdoc}
      */
-    public function check(PhpFileInfo $phpFileInfo)
+    public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet)
     {
         $violations = array();
 
         foreach ($phpFileInfo->superTypeUsages() as $superTypeUsage) {
-            if ($this->ruleSet->hasClass($superTypeUsage->name())) {
+            if ($ruleSet->hasClass($superTypeUsage->name())) {
                 $violations[] = new Violation(
                     $superTypeUsage,
                     $phpFileInfo,
-                    $this->ruleSet->getClass($superTypeUsage->name())->comment()
+                    $ruleSet->getClass($superTypeUsage->name())->comment()
                 );
             }
         }

--- a/src/Violation/ViolationChecker/TypeHintViolationChecker.php
+++ b/src/Violation/ViolationChecker/TypeHintViolationChecker.php
@@ -11,36 +11,23 @@ use SensioLabs\DeprecationDetector\Violation\Violation;
 class TypeHintViolationChecker implements ViolationCheckerInterface
 {
     /**
-     * @var RuleSet
-     */
-    private $ruleSet;
-
-    /**
-     * @param RuleSet $ruleSet
-     */
-    public function __construct(RuleSet $ruleSet)
-    {
-        $this->ruleSet = $ruleSet;
-    }
-
-    /**
      * {@inheritdoc}
      */
-    public function check(PhpFileInfo $phpFileInfo)
+    public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet)
     {
         $violations = array();
 
         foreach ($phpFileInfo->typeHintUsages() as $typeHintUsage) {
-            $isClass = $this->ruleSet->hasClass($typeHintUsage->name());
+            $isClass = $ruleSet->hasClass($typeHintUsage->name());
 
-            if ($isClass || $this->ruleSet->hasInterface($typeHintUsage->name())) {
+            if ($isClass || $ruleSet->hasInterface($typeHintUsage->name())) {
                 $usage = $isClass ?
                     new ClassUsage($typeHintUsage->name(), $typeHintUsage->getLineNumber()) :
                     new InterfaceUsage($typeHintUsage->name(), '', $typeHintUsage->getLineNumber());
 
                 $comment = $isClass ?
-                    $this->ruleSet->getClass($typeHintUsage->name())->comment() :
-                    $this->ruleSet->getInterface($typeHintUsage->name())->comment();
+                    $ruleSet->getClass($typeHintUsage->name())->comment() :
+                    $ruleSet->getInterface($typeHintUsage->name())->comment();
 
                 $violations[] = new Violation(
                     $usage,

--- a/src/Violation/ViolationChecker/ViolationCheckerInterface.php
+++ b/src/Violation/ViolationChecker/ViolationCheckerInterface.php
@@ -3,14 +3,15 @@
 namespace SensioLabs\DeprecationDetector\Violation\ViolationChecker;
 
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
+use SensioLabs\DeprecationDetector\RuleSet\RuleSet;
 use SensioLabs\DeprecationDetector\Violation\Violation;
 
 interface ViolationCheckerInterface
 {
     /**
      * @param PhpFileInfo $phpFileInfo
-     *
-     * @return Violation[]
+     * @param RuleSet $ruleSet
+     * @return \SensioLabs\DeprecationDetector\Violation\Violation[]
      */
-    public function check(PhpFileInfo $phpFileInfo);
+    public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet);
 }

--- a/src/Violation/ViolationChecker/ViolationCheckerInterface.php
+++ b/src/Violation/ViolationChecker/ViolationCheckerInterface.php
@@ -4,13 +4,13 @@ namespace SensioLabs\DeprecationDetector\Violation\ViolationChecker;
 
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\RuleSet\RuleSet;
-use SensioLabs\DeprecationDetector\Violation\Violation;
 
 interface ViolationCheckerInterface
 {
     /**
      * @param PhpFileInfo $phpFileInfo
-     * @param RuleSet $ruleSet
+     * @param RuleSet     $ruleSet
+     *
      * @return \SensioLabs\DeprecationDetector\Violation\Violation[]
      */
     public function check(PhpFileInfo $phpFileInfo, RuleSet $ruleSet);


### PR DESCRIPTION
Moved getViolations() from the Command to a new ViolationDetector class to improve separation of concerns.

Passing the ruleset as method argument instead of constructor argument to be able to instantiate the checkers in the container (checkers might as well be services now, but I simply instantiate them in the container for now).