### PR TITLE
The loaders should implement the loader interface

### DIFF
--- a/src/RuleSet/Loader/DirectoryLoader.php
+++ b/src/RuleSet/Loader/DirectoryLoader.php
@@ -10,7 +10,7 @@ use SensioLabs\DeprecationDetector\RuleSet\Traverser;
  *
  * @author Christopher Hertel <christopher.hertel@sensiolabs.de>
  */
-class DirectoryLoader
+class DirectoryLoader implements LoaderInterface
 {
     /**
      * @var Traverser
@@ -33,7 +33,7 @@ class DirectoryLoader
     }
 
     /**
-     * @see LoaderInterface
+     * {@inheritdoc}
      */
     public function loadRuleSet($path)
     {

--- a/src/RuleSet/Loader/FileLoader.php
+++ b/src/RuleSet/Loader/FileLoader.php
@@ -12,7 +12,7 @@ use Symfony\Component\Finder\SplFileInfo;
  *
  * @author Christopher Hertel <christopher.hertel@sensiolabs.de>
  */
-class FileLoader
+class FileLoader implements LoaderInterface
 {
     /**
      * @var EventDispatcher
@@ -28,7 +28,7 @@ class FileLoader
     }
 
     /**
-     * @see LoaderInterface
+     * {@inheritdoc}
      */
     public function loadRuleSet($path)
     {


### PR DESCRIPTION
There is a `LoaderInterface` and two loader strategies that define the required method. But for some reason, the do not explicitly implement it.

If there's a valid reason why duck-typing was chosen over implementing the interface, please enlighten me. But I find it a bit confusing. ;-)