### PR TITLE
Parser errors noted, but execution continues

### DIFF
--- a/src/Console/Command/CheckCommand.php
+++ b/src/Console/Command/CheckCommand.php
@@ -153,6 +153,12 @@ EOF
 
         $container['violation.renderer']->renderViolations($violations);
 
+        if ($files->hasParserErrors()) {
+            foreach($files->getParserErrors() as $ex) {
+                $this->getApplication()->renderException($ex, $output);
+            }
+        }
+        
         return 0;
     }
 

--- a/src/Finder/ParsedPhpFileFinder.php
+++ b/src/Finder/ParsedPhpFileFinder.php
@@ -13,6 +13,11 @@ class ParsedPhpFileFinder extends Finder
      */
     protected $parser;
 
+    /**
+     * @var \PhpParser\Error[]
+     */
+    protected $parserErrors = array();
+
     public function __construct()
     {
         parent::__construct();
@@ -45,8 +50,7 @@ class ParsedPhpFileFinder extends Finder
                 } catch (\PhpParser\Error $ex) {
                     $raw = $ex->getRawMessage() . ' in file ' . $ex->getFile();
                     $ex->setRawMessage($raw);
-
-                    throw $ex;
+                    $this->parserErrors[] = $ex;
                 }
             }
 

--- a/src/Finder/ParsedPhpFileFinder.php
+++ b/src/Finder/ParsedPhpFileFinder.php
@@ -48,7 +48,7 @@ class ParsedPhpFileFinder extends Finder
                 try {
                     $this->parser->parseFile($file);
                 } catch (\PhpParser\Error $ex) {
-                    $raw = $ex->getRawMessage() . ' in file ' . $ex->getFile();
+                    $raw = $ex->getRawMessage() . ' in file ' . $file;
                     $ex->setRawMessage($raw);
                     $this->parserErrors[] = $ex;
                 }
@@ -66,5 +66,21 @@ class ParsedPhpFileFinder extends Finder
     public function count()
     {
         return iterator_count(parent::getIterator());
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasParserErrors()
+    {
+        return (bool)count($this->parserErrors);
+    }
+
+    /**
+     * @return \PhpParser\Error[]
+     */
+    public function getParserErrors()
+    {
+        return $this->parserErrors;
     }
 }

--- a/src/Finder/ParsedPhpFileFinder.php
+++ b/src/Finder/ParsedPhpFileFinder.php
@@ -73,7 +73,7 @@ class ParsedPhpFileFinder extends Finder
      */
     public function hasParserErrors()
     {
-        return (bool)count($this->parserErrors);
+        return !empty($this->parserErrors);;
     }
 
     /**


### PR DESCRIPTION
This is a fix for #10 Output failing file on syntax error.

ParsedPhpFileFinder has been modified to collect PhpParser\Error and expose them to the outside.
CheckCommand can now detect if there were any parser errors and print them to the command line, but actual execution of the application continues