### PR TITLE
#20 Add composer support

### DIFF
--- a/bin/deprecation-detector
+++ b/bin/deprecation-detector
@@ -4,8 +4,10 @@
 if (file_exists(__DIR__ . '/../../../autoload.php')) {
     // deprecation-detector is part of a composer installation
     require_once __DIR__ . '/../../../autoload.php';
-} else {
+} elseif (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
+} else {
+    die('Missing file vendor/autoload.php. Please run "composer install"!' . PHP_EOL);
 }
 
 set_time_limit(0);

--- a/bin/deprecation-detector
+++ b/bin/deprecation-detector
@@ -1,7 +1,12 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__.'/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    // deprecation-detector is part of a composer installation
+    require_once __DIR__ . '/../../../autoload.php';
+} else {
+    require __DIR__ . '/../vendor/autoload.php';
+}
 
 set_time_limit(0);
 


### PR DESCRIPTION
I fixed including the autoloader.php to enable the deprecation-detector working correctly from inside the vendor directory.

Having an own composer.json:
```
{
    "repositories": [
        { "type": "vcs", "url": "https://github.com/DrSchimke/deprecation-detector" }
    ],
    "require-dev": {
        "sensiolabs/deprecation-detector": "dev-issue-20"
    },
    "config": { "bin-dir": "bin" }
}
```

and calling `composer install` will create an `bin/` directory with a symlink to the package's own executable.

For the right integration into composer, someone needs to add the package to packagist.org, please.