### PR TITLE
Removed more usages of the short array syntax

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -298,14 +298,14 @@ class Application extends BaseApplication
 
         $c['violation_checker'] = function ($c) {
             return new ComposedViolationChecker(
-                [
+                array(
                     new ClassViolationChecker(),
                     new InterfaceViolationChecker(),
                     new MethodViolationChecker($c['ancestor_resolver']),
                     new SuperTypeViolationChecker(),
                     new TypeHintViolationChecker(),
                     new MethodDefinitionViolationChecker($c['ancestor_resolver']),
-                ]
+                )
             );
         };
 


### PR DESCRIPTION
I've found another usage of the short array syntax, introduced after my PR addressing PHP 5.3 compatibility. Maybe we should add a php lint to the travis configuration?