### PR TITLE
Use the composer cache on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
     - composer self-update
 
 install:
-    - composer install --dev --prefer-source
+    - composer install
 
 script:
     - bin/phpunit


### PR DESCRIPTION
When forcing a source install, the composer cache cannot be used, as it caches downloads only.

Note that the cache will enter into effect only once you have a build running without reaching the API limit. As long as builds are falling back to a source install because of the rate limit, these deps won't be cached (which is already the current behavior btw)

On a side note, locking dependencies (see #47) would make cache hits much more likely, as it would miss only on dependency updates once the cache is warm.