### PR TITLE
no longer ignore tests in box config

### DIFF
--- a/box.json
+++ b/box.json
@@ -14,7 +14,6 @@
         },
         {
             "name": "*.*",
-            "exclude": ["Tests"],
             "in": "src"
         }
     ],


### PR DESCRIPTION
No that tests have been moved out of the `src` directoriy, there is no
need to ignore the test files anymore (as there are no inside `src/`).