### PR TITLE
fix missing dependancy: Expression langage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "symfony/event-dispatcher": "^2.7",
         "pimple/pimple": "~3.0",
         "symfony/dependency-injection": "^2.7",
-        "symfony/config": "^2.7"
+        "symfony/config": "^2.7",
+        "symfony/expression-language": "^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "35723ceb4d775bfcf0ac2eb87a00b0c8",
+    "hash": "17fc193c1f6a443d87874fb325bd280f",
+    "content-hash": "96c50beb8f3f3e5edee2bab0561d4730",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -370,6 +371,55 @@
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
             "time": "2015-09-22 13:49:29"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v2.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "539de1f520cd1c4073e2776dc734262f21ad96de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/539de1f520cd1c4073e2776dc734262f21ad96de",
+                "reference": "539de1f520cd1c4073e2776dc734262f21ad96de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ExpressionLanguage Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-09-24 11:58:55"
         },
         {
             "name": "symfony/filesystem",


### PR DESCRIPTION
On some of my symfony project I get this error, no matter if I use source or build a phar.
```bash
PHP Fatal error:  Class 'Symfony\Component\ExpressionLanguage\Expression' not found in /home/ulusseau/github/deprecation-detector/vendor/symfony/dependency-injection/Loader/XmlFileLoader.php on line 384
PHP Stack trace:
PHP   1. {main}() /home/ulusseau/github/deprecation-detector/bin/deprecation-detector:0
PHP   2. Symfony\Component\Console\Application->run() /home/ulusseau/github/deprecation-detector/bin/deprecation-detector:18
PHP   3. Symfony\Component\Console\Application->doRun() /home/ulusseau/github/deprecation-detector/vendor/symfony/console/Application.php:126
PHP   4. Symfony\Component\Console\Application->doRunCommand() /home/ulusseau/github/deprecation-detector/vendor/symfony/console/Application.php:195
PHP   5. Symfony\Component\Console\Command\Command->run() /home/ulusseau/github/deprecation-detector/vendor/symfony/console/Application.php:886
PHP   6. SensioLabs\DeprecationDetector\Console\Command\CheckCommand->execute() /home/ulusseau/github/deprecation-detector/vendor/symfony/console/Command/Command.php:259
PHP   7. SensioLabs\DeprecationDetector\TypeGuessing\Symfony\ContainerReader->loadContainer() /home/ulusseau/github/deprecation-detector/src/Console/Command/CheckCommand.php:111
PHP   8. Symfony\Component\DependencyInjection\Loader\XmlFileLoader->load() /home/ulusseau/github/deprecation-detector/src/TypeGuessing/Symfony/ContainerReader.php:36
PHP   9. Symfony\Component\DependencyInjection\Loader\XmlFileLoader->parseDefinitions() /home/ulusseau/github/deprecation-detector/vendor/symfony/dependency-injection/Loader/XmlFileLoader.php:58
PHP  10. Symfony\Component\DependencyInjection\Loader\XmlFileLoader->parseDefinition() /home/ulusseau/github/deprecation-detector/vendor/symfony/dependency-injection/Loader/XmlFileLoader.php:118
PHP  11. Symfony\Component\DependencyInjection\Loader\XmlFileLoader->getArgumentsAsPhp() /home/ulusseau/github/deprecation-detector/vendor/symfony/dependency-injection/Loader/XmlFileLoader.php:174
```

Adding Expression Language in project dependancy fix problem and don't seems to add other bug.