### PR TITLE
Prevent displaying misleading violations and errors output when there are none

### DIFF
--- a/src/Violation/Renderer/ConsoleOutputRenderer.php
+++ b/src/Violation/Renderer/ConsoleOutputRenderer.php
@@ -39,6 +39,19 @@ class ConsoleOutputRenderer implements RendererInterface
      */
     public function renderViolations(array $violations, array $errors)
     {
+        $this->printViolations($violations);
+        $this->printErrors($errors);
+    }
+
+    /**
+     * @param Violation[] $violations
+     */
+    private function printViolations(array $violations)
+    {
+        if (0 === count($violations)) {
+            return;
+        }
+
         $table = new Table($this->output);
         $table->setHeaders(array('#', 'Usage', 'Line', 'Comment'));
 
@@ -62,6 +75,16 @@ class ConsoleOutputRenderer implements RendererInterface
         }
 
         $table->render();
+    }
+
+    /**
+     * @param Error[] $errors
+     */
+    private function printErrors(array $errors)
+    {
+        if (0 === count($errors)) {
+            return;
+        }
 
         $this->output->writeln('<error>Your project contains invalid code:</error>');
         foreach ($errors as $error) {


### PR DESCRIPTION
When I used this tool for the first time I got a bunch of deprecations (which I expected) but after fixing all of them I got the following output, which confused the hell out of me since I thought there was something so wrong that even this analyzer is breaking. However, after reading through the source I got the confirmation that this tool is always printing the table and headling (`Your project contains invalid code:` etc.) even when there are no errors.

Before the changes:
![image](https://cloud.githubusercontent.com/assets/439899/11837021/8f3eff78-a3de-11e5-8c0a-ec2c5d98ece2.png)

After:
![image](https://cloud.githubusercontent.com/assets/439899/11837033/a5ae8d78-a3de-11e5-9d77-0b773eadc39d.png)
