### PR TITLE
Fix fatal error when calling DirectoryTraverser::traverse()

### DIFF
--- a/src/RuleSet/Loader/ComposerLoader.php
+++ b/src/RuleSet/Loader/ComposerLoader.php
@@ -112,7 +112,7 @@ class ComposerLoader implements LoaderInterface
         if ($this->cache->has($key)) {
             $ruleSet = $this->cache->getCachedRuleSet($key);
         } elseif (is_dir($path = $this->getPackagePath($package))) {
-            $ruleSet = $this->traverser->traverse($path, true);
+            $ruleSet = $this->traverser->traverse($path);
             $this->cache->cacheRuleSet($key, $ruleSet);
         }
 


### PR DESCRIPTION
The method was called with an extra boolean parameter, instead of null/a RuleSet

Fix https://github.com/sensiolabs-de/deprecation-detector/issues/89