### PR TITLE
Changed the ParsedPhpFileFinder into a stateless service

### DIFF
--- a/src/DeprecationDetector.php
+++ b/src/DeprecationDetector.php
@@ -96,16 +96,15 @@ class DeprecationDetector
             $lib,
         ));
 
-        /** @var ParsedPhpFileFinder $files */
-        $files = $this->deprecationFinder->in($sourceArg);
-        $violations = $this->violationDetector->getViolations($ruleSet, $files);
+        $result = $this->deprecationFinder->parsePhpFiles($sourceArg);
+        $violations = $this->violationDetector->getViolations($ruleSet, $result->parsedFiles());
         $this->output->endUsageDetection();
 
         $this->output->startOutputRendering();
-        $this->renderer->renderViolations($violations, $files->getParserErrors());
+        $this->renderer->renderViolations($violations, $result->parserErrors());
         $this->output->endOutputRendering();
 
-        $this->output->endProgress($files->count(), count($violations));
+        $this->output->endProgress($result->fileCount(), count($violations));
 
         return $violations;
     }

--- a/src/DetectorFactory.php
+++ b/src/DetectorFactory.php
@@ -292,6 +292,7 @@ class DetectorFactory
     /**
      * @param Configuration   $configuration
      * @param OutputInterface $output
+     *
      * @return ConsoleOutputRenderer|Violation\Renderer\Html\Renderer
      */
     private function getRenderer(Configuration $configuration, OutputInterface $output)

--- a/src/DetectorFactory.php
+++ b/src/DetectorFactory.php
@@ -9,7 +9,9 @@ use SensioLabs\DeprecationDetector\Console\Output\DefaultProgressOutput;
 use SensioLabs\DeprecationDetector\Console\Output\VerboseProgressOutput;
 use SensioLabs\DeprecationDetector\FileInfo\Deprecation\FunctionDeprecation;
 use SensioLabs\DeprecationDetector\FileInfo\Deprecation\MethodDeprecation;
+use SensioLabs\DeprecationDetector\Finder\DeprecationFinderFactory;
 use SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder;
+use SensioLabs\DeprecationDetector\Finder\UsageFinderFactory;
 use SensioLabs\DeprecationDetector\Parser\DeprecationParser;
 use SensioLabs\DeprecationDetector\Parser\UsageParser;
 use SensioLabs\DeprecationDetector\RuleSet\Cache;
@@ -100,9 +102,10 @@ class DetectorFactory
             'Deprecation detection'
         );
         $deprecationUsageParser = $this->getUsageParser($configuration);
-        $deprecationUsageFinder = ParsedPhpFileFinder::usageFinder(
+        $deprecationUsageFinder = new ParsedPhpFileFinder(
             $deprecationUsageParser,
-            $deprecationProgressOutput
+            $deprecationProgressOutput,
+            new UsageFinderFactory()
         );
 
         $this->ancestorResolver = new AncestorResolver($deprecationUsageParser);
@@ -113,9 +116,10 @@ class DetectorFactory
             'RuleSet generation'
         );
         $ruleSetDeprecationParser = $this->getDeprecationParser();
-        $ruleSetDeprecationFinder = ParsedPhpFileFinder::deprecationFinder(
+        $ruleSetDeprecationFinder = new ParsedPhpFileFinder(
             $ruleSetDeprecationParser,
-            $ruleSetProgressOutput
+            $ruleSetProgressOutput,
+            new DeprecationFinderFactory()
         );
         $deprecationDirectoryTraverser = new DirectoryTraverser($ruleSetDeprecationFinder);
 

--- a/src/Finder/DeprecationFinderFactory.php
+++ b/src/Finder/DeprecationFinderFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Finder;
+
+use Symfony\Component\Finder\Finder;
+
+class DeprecationFinderFactory implements FinderFactoryInterface
+{
+    public function createFinder()
+    {
+        $finder = new Finder();
+        $finder
+            ->name('*.php')
+            ->contains('@deprecated')
+            ->exclude('vendor')
+            ->exclude('Tests')
+            ->exclude('Test');
+
+        return $finder;
+    }
+}
+

--- a/src/Finder/DeprecationFinderFactory.php
+++ b/src/Finder/DeprecationFinderFactory.php
@@ -19,4 +19,3 @@ class DeprecationFinderFactory implements FinderFactoryInterface
         return $finder;
     }
 }
-

--- a/src/Finder/FinderFactoryInterface.php
+++ b/src/Finder/FinderFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Finder;
+
+use Symfony\Component\Finder\Finder;
+
+interface FinderFactoryInterface
+{
+    /**
+     * @return Finder
+     */
+    public function createFinder();
+}

--- a/src/Finder/ParsedPhpFileFinder.php
+++ b/src/Finder/ParsedPhpFileFinder.php
@@ -5,7 +5,6 @@ namespace SensioLabs\DeprecationDetector\Finder;
 use SensioLabs\DeprecationDetector\Console\Output\VerboseProgressOutput;
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\Parser\ParserInterface;
-use Symfony\Component\Finder\Finder;
 use PhpParser\Error;
 
 class ParsedPhpFileFinder
@@ -26,9 +25,9 @@ class ParsedPhpFileFinder
     private $finderFactory;
 
     /**
-     * @param ParserInterface           $parser
-     * @param VerboseProgressOutput     $progressOutput
-     * @param FinderFactoryInterface    $finderFactory
+     * @param ParserInterface        $parser
+     * @param VerboseProgressOutput  $progressOutput
+     * @param FinderFactoryInterface $finderFactory
      */
     public function __construct(ParserInterface $parser, VerboseProgressOutput $progressOutput, FinderFactoryInterface $finderFactory)
     {
@@ -39,6 +38,7 @@ class ParsedPhpFileFinder
 
     /**
      * @param string $path
+     *
      * @return Result
      */
     public function parsePhpFiles($path)
@@ -66,6 +66,7 @@ class ParsedPhpFileFinder
         }
 
         $this->progressOutput->end();
+
         return new Result($parsedFiles, $parserErrors, $fileCount);
     }
 }

--- a/src/Finder/Result.php
+++ b/src/Finder/Result.php
@@ -15,8 +15,8 @@ class Result
 
     /**
      * @param PhpFileInfo[] $files
-     * @param Error[] $errors
-     * @param int $fileCount
+     * @param Error[]       $errors
+     * @param int           $fileCount
      */
     public function __construct(array $files, array $errors, $fileCount)
     {

--- a/src/Finder/Result.php
+++ b/src/Finder/Result.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Finder;
+
+use PhpParser\Error;
+use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
+
+class Result
+{
+    private $files;
+
+    private $errors;
+
+    private $fileCount;
+
+    /**
+     * @param PhpFileInfo[] $files
+     * @param Error[] $errors
+     * @param int $fileCount
+     */
+    public function __construct(array $files, array $errors, $fileCount)
+    {
+        $this->files = $files;
+        $this->errors = $errors;
+        $this->fileCount = $fileCount;
+    }
+
+    public function parsedFiles()
+    {
+        return $this->files;
+    }
+
+    public function parserErrors()
+    {
+        return $this->errors;
+    }
+
+    public function fileCount()
+    {
+        return $this->fileCount;
+    }
+}

--- a/src/Finder/UsageFinderFactory.php
+++ b/src/Finder/UsageFinderFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Finder;
+
+use Symfony\Component\Finder\Finder;
+
+class UsageFinderFactory implements FinderFactoryInterface
+{
+    public function createFinder()
+    {
+        $finder = new Finder();
+        $finder
+            ->name('*.php')
+            ->exclude('vendor')
+            ->exclude('Tests')
+            ->exclude('Test');
+
+        return $finder;
+    }
+}

--- a/src/RuleSet/DirectoryTraverser.php
+++ b/src/RuleSet/DirectoryTraverser.php
@@ -2,14 +2,8 @@
 
 namespace SensioLabs\DeprecationDetector\RuleSet;
 
-use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder;
 
-/**
- * Class Traverser.
- *
- * @author Christopher Hertel <christopher.hertel@sensiolabs.de>
- */
 class DirectoryTraverser
 {
     /**
@@ -33,27 +27,18 @@ class DirectoryTraverser
      */
     public function traverse($path, RuleSet $ruleSet = null)
     {
-        $files = $this->finder->in($path);
+        $result = $this->finder->parsePhpFiles($path);
 
         if (!$ruleSet instanceof RuleSet) {
             $ruleSet = new RuleSet();
         }
 
-        foreach ($files as $i => $file) {
-            /** @var PhpFileInfo $file */
+        foreach ($result->parsedFiles() as $file) {
             if ($file->hasDeprecations()) {
                 $ruleSet->merge($file);
             }
         }
 
         return $ruleSet;
-    }
-
-    public function reset()
-    {
-        $this->finder = ParsedPhpFileFinder::deprecationFinder(
-            $this->finder->getParser(),
-            $this->finder->getOutput()
-        );
     }
 }

--- a/src/RuleSet/Loader/Composer/ComposerLoader.php
+++ b/src/RuleSet/Loader/Composer/ComposerLoader.php
@@ -73,7 +73,6 @@ class ComposerLoader implements LoaderInterface
         if ($this->cache->has($key)) {
             $ruleSet = $this->cache->getCachedRuleSet($key);
         } elseif (is_dir($path = $package->getPackagePath(self::PACKAGE_PATH))) {
-            $this->traverser->reset();
             $ruleSet = $this->traverser->traverse($path);
             $this->cache->cacheRuleSet($key, $ruleSet);
         } else {

--- a/src/Violation/ViolationDetector.php
+++ b/src/Violation/ViolationDetector.php
@@ -33,8 +33,8 @@ class ViolationDetector
     }
 
     /**
-     * @param RuleSet             $ruleSet
-     * @param PhpFileInfo[]       $files
+     * @param RuleSet       $ruleSet
+     * @param PhpFileInfo[] $files
      *
      * @return BaseViolation[]
      */

--- a/src/Violation/ViolationDetector.php
+++ b/src/Violation/ViolationDetector.php
@@ -2,7 +2,7 @@
 
 namespace SensioLabs\DeprecationDetector\Violation;
 
-use SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder;
+use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\RuleSet\RuleSet;
 use SensioLabs\DeprecationDetector\Violation\Violation as BaseViolation;
 use SensioLabs\DeprecationDetector\Violation\ViolationChecker\ViolationCheckerInterface;
@@ -34,11 +34,11 @@ class ViolationDetector
 
     /**
      * @param RuleSet             $ruleSet
-     * @param ParsedPhpFileFinder $files
+     * @param PhpFileInfo[]       $files
      *
      * @return BaseViolation[]
      */
-    public function getViolations(RuleSet $ruleSet, ParsedPhpFileFinder $files)
+    public function getViolations(RuleSet $ruleSet, array $files)
     {
         $result = array();
         foreach ($files as $i => $file) {

--- a/tests/Console/Command/CheckCommandTest.php
+++ b/tests/Console/Command/CheckCommandTest.php
@@ -90,11 +90,11 @@ class CheckCommandTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Helper method for simplified executing of CheckCommand
+     * Helper method for simplified executing of CheckCommand.
      *
-     * @param string $sourcePath     source argument
-     * @param string $rulesetPath    ruleset argument
-     * @param array $options Further options as key => value array
+     * @param string $sourcePath  source argument
+     * @param string $rulesetPath ruleset argument
+     * @param array  $options     Further options as key => value array
      */
     private function executeCommand($sourcePath, $rulesetPath, array $options = array())
     {

--- a/tests/DeprecationDetectorTest.php
+++ b/tests/DeprecationDetectorTest.php
@@ -49,10 +49,13 @@ class DeprecationDetectorTest extends \PHPUnit_Framework_TestCase
         $ancestorResolver = $this->prophesize('SensioLabs\DeprecationDetector\TypeGuessing\AncestorResolver');
         $ancestorResolver->setSourcePaths(Argument::any())->shouldBeCalled();
 
+        $deprecationResult = $this->prophesize('SensioLabs\DeprecationDetector\Finder\Result');
+        $deprecationResult->parsedFiles()->willReturn($parsedFiles = array());
+        $deprecationResult->fileCount()->willReturn($fileCount);
+        $deprecationResult->parserErrors()->willReturn(array());
+
         $deprecationFinder = $this->prophesize('SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder');
-        $deprecationFinder->in($sourceArg)->willReturn($deprecationFinder->reveal());
-        $deprecationFinder->count()->willReturn($fileCount);
-        $deprecationFinder->getParserErrors()->willReturn(array());
+        $deprecationFinder->parsePhpFiles($sourceArg)->willReturn($deprecationResult->reveal());
 
         $aViolation = $this->prophesize('SensioLabs\DeprecationDetector\Violation\Violation');
         $anotherViolation = $this->prophesize('SensioLabs\DeprecationDetector\Violation\Violation');
@@ -62,71 +65,10 @@ class DeprecationDetectorTest extends \PHPUnit_Framework_TestCase
         );
 
         $violationDetector = $this->prophesize('SensioLabs\DeprecationDetector\Violation\ViolationDetector');
-        $violationDetector->getViolations($ruleSet->reveal(), $deprecationFinder->reveal())->willReturn($violations);
+        $violationDetector->getViolations($ruleSet->reveal(), $parsedFiles)->willReturn($violations);
 
         $renderer = $this->prophesize('SensioLabs\DeprecationDetector\Violation\Renderer\RendererInterface');
         $renderer->renderViolations($violations, array())->shouldBeCalled();
-
-        $defaultOutput = $this->prophesize(
-            'SensioLabs\DeprecationDetector\Console\Output\DefaultProgressOutput'
-        );
-        $defaultOutput->startProgress()->shouldBeCalled();
-        $defaultOutput->startRuleSetGeneration()->shouldBeCalled();
-        $defaultOutput->endRuleSetGeneration()->shouldBeCalled();
-        $defaultOutput->startUsageDetection()->shouldBeCalled();
-        $defaultOutput->endUsageDetection()->shouldBeCalled();
-        $defaultOutput->startOutputRendering()->shouldBeCalled();
-        $defaultOutput->endOutputRendering()->shouldBeCalled();
-        $defaultOutput->endProgress($fileCount, $violationCount)->shouldBeCalled();
-
-        $detector = new DeprecationDetector(
-            $preDefinedRuleSet->reveal(),
-            $ruleSetLoader->reveal(),
-            $ancestorResolver->reveal(),
-            $deprecationFinder->reveal(),
-            $violationDetector->reveal(),
-            $renderer->reveal(),
-            $defaultOutput->reveal()
-        );
-
-        $this->assertSame($violations, $detector->checkForDeprecations($sourceArg, $ruleSetArg));
-    }
-
-    public function testCheckForDeprecationsRendersParserErrorsIfThereAreAny()
-    {
-        $preDefinedRuleSet = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\RuleSet');
-
-        $sourceArg = 'path/to/ruleset';
-        $ruleSetArg = 'path/to/source/code';
-        $parserErrors = array();
-        $fileCount = 10;
-        $violationCount = 2;
-
-        $ruleSet = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\RuleSet');
-        $ruleSet->merge($preDefinedRuleSet->reveal())->shouldBeCalled();
-        $ruleSetLoader = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\Loader\LoaderInterface');
-        $ruleSetLoader->loadRuleSet($ruleSetArg)->willReturn($ruleSet->reveal());
-
-        $ancestorResolver = $this->prophesize('SensioLabs\DeprecationDetector\TypeGuessing\AncestorResolver');
-        $ancestorResolver->setSourcePaths(Argument::any())->shouldBeCalled();
-
-        $deprecationFinder = $this->prophesize('SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder');
-        $deprecationFinder->in($sourceArg)->willReturn($deprecationFinder->reveal());
-        $deprecationFinder->count()->willReturn($fileCount);
-        $deprecationFinder->getParserErrors()->willReturn($parserErrors);
-
-        $aViolation = $this->prophesize('SensioLabs\DeprecationDetector\Violation\Violation');
-        $anotherViolation = $this->prophesize('SensioLabs\DeprecationDetector\Violation\Violation');
-        $violations = array(
-            $aViolation->reveal(),
-            $anotherViolation->reveal(),
-        );
-
-        $violationDetector = $this->prophesize('SensioLabs\DeprecationDetector\Violation\ViolationDetector');
-        $violationDetector->getViolations($ruleSet->reveal(), $deprecationFinder->reveal())->willReturn($violations);
-
-        $renderer = $this->prophesize('SensioLabs\DeprecationDetector\Violation\Renderer\RendererInterface');
-        $renderer->renderViolations($violations, $parserErrors)->shouldBeCalled();
 
         $defaultOutput = $this->prophesize(
             'SensioLabs\DeprecationDetector\Console\Output\DefaultProgressOutput'

--- a/tests/FileInfo/Usage/DeprecatedLanguageUsageTest.php
+++ b/tests/FileInfo/Usage/DeprecatedLanguageUsageTest.php
@@ -2,7 +2,6 @@
 
 namespace SensioLabs\DeprecationDetector\Tests\FileInfo\Usage;
 
-
 use SensioLabs\DeprecationDetector\FileInfo\Usage\DeprecatedLanguageUsage;
 
 class DeprecatedLanguageUsageTest extends \PHPUnit_Framework_TestCase

--- a/tests/Finder/DeprecationFinderFactoryTest.php
+++ b/tests/Finder/DeprecationFinderFactoryTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Tests\Finder;
+
+use SensioLabs\DeprecationDetector\Finder\DeprecationFinderFactory;
+
+class DeprecationFinderFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateFinder()
+    {
+        $factory = new DeprecationFinderFactory();
+
+        $this->assertInstanceOf('Symfony\Component\Finder\Finder', $factory->createFinder());
+    }
+}

--- a/tests/Finder/ParsedPhpFileFinderTest.php
+++ b/tests/Finder/ParsedPhpFileFinderTest.php
@@ -12,10 +12,12 @@ class ParsedPhpFileFinderTest extends \PHPUnit_Framework_TestCase
         $progressOutput = $this->prophesize(
             'SensioLabs\DeprecationDetector\Console\Output\VerboseProgressOutput'
         );
+        $finderFactory = $this->prophesize('SensioLabs\DeprecationDetector\Finder\FinderFactoryInterface');
 
         $finder = new ParsedPhpFileFinder(
             $parser->reveal(),
-            $progressOutput->reveal()
+            $progressOutput->reveal(),
+            $finderFactory->reveal()
         );
 
         $this->assertInstanceOf('SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder', $finder);

--- a/tests/Finder/ResultTest.php
+++ b/tests/Finder/ResultTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Tests\Finder;
+
+use SensioLabs\DeprecationDetector\Finder\Result;
+
+class ResultTest extends \PHPUnit_Framework_TestCase
+{
+    public function testClassIsInitializable()
+    {
+        $result = new Result(array(), array(), 10);
+
+        $this->assertInstanceOf('SensioLabs\DeprecationDetector\Finder\Result', $result);
+    }
+
+    public function testParsedFiles()
+    {
+        $parsedFiles = array(
+            $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo')
+        );
+
+        $result = new Result($parsedFiles, array(), 10);
+
+        $this->assertSame($parsedFiles, $result->parsedFiles());
+    }
+
+    public function testParserErrors()
+    {
+        $parserErrors = array(
+            $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo')
+        );
+
+        $result = new Result(array(), $parserErrors, 10);
+
+        $this->assertSame($parserErrors, $result->parserErrors());
+    }
+
+    public function testFileCount()
+    {
+        $result = new Result(array(), array(), 10);
+
+        $this->assertSame(10, $result->fileCount());
+    }
+}

--- a/tests/Finder/ResultTest.php
+++ b/tests/Finder/ResultTest.php
@@ -16,7 +16,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
     public function testParsedFiles()
     {
         $parsedFiles = array(
-            $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo')
+            $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo'),
         );
 
         $result = new Result($parsedFiles, array(), 10);
@@ -27,7 +27,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
     public function testParserErrors()
     {
         $parserErrors = array(
-            $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo')
+            $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo'),
         );
 
         $result = new Result(array(), $parserErrors, 10);

--- a/tests/Finder/UsageFinderFactoryTest.php
+++ b/tests/Finder/UsageFinderFactoryTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Tests\Finder;
+
+use SensioLabs\DeprecationDetector\Finder\UsageFinderFactory;
+
+class UsageFinderFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateFinder()
+    {
+        $factory = new UsageFinderFactory();
+
+        $this->assertInstanceOf('Symfony\Component\Finder\Finder', $factory->createFinder());
+    }
+}

--- a/tests/RuleSet/DirectoryTraverserTest.php
+++ b/tests/RuleSet/DirectoryTraverserTest.php
@@ -26,11 +26,14 @@ class DirectoryTraverserTest extends \PHPUnit_Framework_TestCase
         $anotherPhpFileInfo = $this->prophesize('SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo');
         $anotherPhpFileInfo->hasDeprecations()->willReturn(false);
 
-        $deprecationFileFinder = $this->prophesize('SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder');
-        $deprecationFileFinder->in('some_dir')->willReturn(array(
+        $deprecationResult = $this->prophesize('SensioLabs\DeprecationDetector\Finder\Result');
+        $deprecationResult->parsedFiles()->willReturn(array(
             $aPhpFileInfo->reveal(),
             $anotherPhpFileInfo->reveal(),
         ));
+
+        $deprecationFileFinder = $this->prophesize('SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder');
+        $deprecationFileFinder->parsePhpFiles('some_dir')->willReturn($deprecationResult->reveal());
 
         $ruleSet = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\RuleSet');
         $ruleSet->merge($aPhpFileInfo->reveal())->shouldBeCalled();

--- a/tests/RuleSet/Loader/Composer/ComposerLoaderTest.php
+++ b/tests/RuleSet/Loader/Composer/ComposerLoaderTest.php
@@ -85,7 +85,6 @@ class ComposerLoaderTest extends \PHPUnit_Framework_TestCase
 
         $traverser = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\DirectoryTraverser');
         $traverser->traverse(vfsStream::url('root/vendor/avendor/anotherlib'))->willReturn($aVendorAnotherLibRuleSet);
-        $traverser->reset()->shouldBeCalled();
         $cache->cacheRuleSet('vendor_anotherlib_1.0.0', $aVendorAnotherLibRuleSet)->shouldBeCalled();
 
         $factory = $this->prophesize('SensioLabs\DeprecationDetector\RuleSet\Loader\Composer\ComposerFactory');

--- a/tests/Violation/Renderer/Html/RendererFactoryTest.php
+++ b/tests/Violation/Renderer/Html/RendererFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SensioLabs\DeprecationDetector\Tests\Violation\Renderer\Html;
 
 use PHPUnit_Framework_TestCase;
@@ -7,7 +8,7 @@ use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\MessageHelpe
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Class RendererFactoryTest
+ * Class RendererFactoryTest.
  *
  * @author Karl Spies <karl.spies@gmx.net>
  */

--- a/tests/Violation/Renderer/Html/RendererTest.php
+++ b/tests/Violation/Renderer/Html/RendererTest.php
@@ -5,24 +5,22 @@ namespace SensioLabs\DeprecationDetector\Tests\Violation\Renderer\Html;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit_Framework_TestCase;
-use Prophecy\Argument;
 use SensioLabs\DeprecationDetector\Violation\Renderer\Html\Renderer;
 
 /**
- * Class RendererTest
+ * Class RendererTest.
  *
  * @author Karl Spies <karl.spies@gmx.net>
  */
 class RendererTest extends PHPUnit_Framework_TestCase
 {
-
     /**
-     * @var  vfsStreamDirectory
+     * @var vfsStreamDirectory
      */
     private $root;
 
     /**
-     * set up test environment
+     * set up test environment.
      */
     public function setUp()
     {
@@ -61,5 +59,4 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $this->assertContains('12', $fileContent);
         $this->assertContains('Just a comment', $fileContent);
     }
-
 }

--- a/tests/Violation/ViolationDetectorTest.php
+++ b/tests/Violation/ViolationDetectorTest.php
@@ -51,15 +51,9 @@ class ViolationDetectorTest extends \PHPUnit_Framework_TestCase
             $violationFilter->reveal()
         );
 
-
-        $finder = $this->prophesize('SensioLabs\DeprecationDetector\Finder\ParsedPhpFileFinder');
-        $finder->getIterator()->willReturn(
-            new \ArrayIterator(array($phpFileInfo))
-        )->shouldBeCalled();
-
         $this->assertEquals(
             $expected,
-            $violationDetector->getViolations($ruleSet, $finder->reveal())
+            $violationDetector->getViolations($ruleSet, array($phpFileInfo))
         );
     }
 }


### PR DESCRIPTION
The `ParsedPhpFileFinder` is now stateless, therefore the `ComposerLoader` no longer needs to reset the `DirectoryTraverser`  #73