### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,8 @@ matrix:
         - php: 7
     fast_finish: true
 
-before_install:
-    - composer self-update
-
 install:
-    - composer install
+    - composer install --prefer-dist
 
 script:
-    - vendor/bin/phpunit
+    - phpunit


### PR DESCRIPTION
- Remove unneeded `composer self-update` as the Composer binary is automatically updated every ~60 days
- Install dist packages (should speed up the install)
- Use Travis PHPUnit binary

Closes #53