### PR TITLE
Simple Console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ You can get a list of all options and arguments by running
 $ deprecation-detector check --help
 ```
 
+The default output might not fit into the cli. If that is the case you can set the output to a list by setting `--output=simple`.
+
+```bash
+$ deprecation-detector check src/ vendor/ --output=simple
+```
+
 ## Excluding deprecated method calls
 
 You can exclude deprecated method calls by using the `filter-methods` option. This option takes a comma separated list of method references to exclude.

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -150,7 +150,8 @@ class Configuration
     /**
      * @return bool
      */
-    public function isSimpleOutput() {
+    public function isSimpleOutput()
+    {
         return $this->output === 'simple';
     }
 }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -45,6 +45,11 @@ class Configuration
     private $logHtml;
 
     /**
+     * @var string
+     */
+    private $output;
+
+    /**
      * @param string $ruleSet
      * @param string $containerPath
      * @param bool   $noCache
@@ -53,6 +58,7 @@ class Configuration
      * @param bool   $fail
      * @param bool   $verbose
      * @param string $logHtml
+     * @param string $output
      */
     public function __construct(
         $ruleSet,
@@ -62,7 +68,8 @@ class Configuration
         $filterMethodCalls,
         $fail,
         $verbose,
-        $logHtml)
+        $logHtml,
+        $output)
     {
         $this->ruleSet = $ruleSet;
         $this->containerPath = $containerPath;
@@ -72,6 +79,7 @@ class Configuration
         $this->failOnDeprecation = $fail;
         $this->verbose = $verbose;
         $this->logHtml = $logHtml;
+        $this->output = $output;
     }
 
     public function overrideConfiguration()
@@ -137,5 +145,12 @@ class Configuration
     public function logHtml()
     {
         return $this->logHtml;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSimpleOutput() {
+        return $this->output === 'simple';
     }
 }

--- a/src/Console/Command/CheckCommand.php
+++ b/src/Console/Command/CheckCommand.php
@@ -38,6 +38,7 @@ class CheckCommand extends Command
                     new InputOption('no-cache', null, InputOption::VALUE_NONE, 'Disable rule set cache'),
                     new InputOption('cache-dir', null, InputOption::VALUE_REQUIRED, 'Cache directory', '.rules/'),
                     new InputOption('log-html', null, InputOption::VALUE_REQUIRED, 'Generate HTML report'),
+                    new InputOption('output', null, InputOption::VALUE_REQUIRED, 'Change the output mode'),
                     new InputOption('filter-methods', null, InputOption::VALUE_OPTIONAL, 'Filter methods', ''),
                     new InputOption('fail', null, InputOption::VALUE_NONE, 'Fails, if any deprecation is detected'),
                 )
@@ -113,7 +114,8 @@ EOF
             $input->getOption('filter-methods'),
             $input->getOption('fail'),
             $input->getOption('verbose'),
-            $input->getOption('log-html')
+            $input->getOption('log-html'),
+            $input->getOption('output')
         );
 
         $factory = new DetectorFactory();

--- a/src/DetectorFactory.php
+++ b/src/DetectorFactory.php
@@ -35,7 +35,7 @@ use SensioLabs\DeprecationDetector\TypeGuessing\SymbolTable\Resolver\VariableAss
 use SensioLabs\DeprecationDetector\TypeGuessing\SymbolTable\SymbolTable;
 use SensioLabs\DeprecationDetector\TypeGuessing\SymbolTable\Visitor\SymbolTableVariableResolverVisitor;
 use SensioLabs\DeprecationDetector\TypeGuessing\Symfony\ContainerReader;
-use SensioLabs\DeprecationDetector\Violation\Renderer\ConsoleOutputRenderer;
+use SensioLabs\DeprecationDetector\Violation\Renderer\Console\DefaultRenderer;
 use SensioLabs\DeprecationDetector\Violation\Renderer\Html\RendererFactory;
 use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\Message\ClassViolationMessage;
 use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\Message\FunctionViolationMessage;
@@ -45,6 +45,7 @@ use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\Message\Meth
 use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\Message\MethodViolationMessage;
 use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\Message\SuperTypeViolationMessage;
 use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\MessageHelper;
+use SensioLabs\DeprecationDetector\Violation\Renderer\Console\SimpleRenderer;
 use SensioLabs\DeprecationDetector\Violation\ViolationChecker\ClassViolationChecker;
 use SensioLabs\DeprecationDetector\Violation\ViolationChecker\ComposedViolationChecker;
 use SensioLabs\DeprecationDetector\Violation\ViolationChecker\FunctionViolationChecker;
@@ -293,7 +294,7 @@ class DetectorFactory
      * @param Configuration   $configuration
      * @param OutputInterface $output
      *
-     * @return ConsoleOutputRenderer|Violation\Renderer\Html\Renderer
+     * @return DefaultRenderer|Violation\Renderer\Html\Renderer
      */
     private function getRenderer(Configuration $configuration, OutputInterface $output)
     {
@@ -305,7 +306,11 @@ class DetectorFactory
             return $factory->createHtmlOutputRenderer($logFilePath);
         }
 
-        return new ConsoleOutputRenderer($output, $messageHelper);
+        if ($configuration->isSimpleOutput()) {
+            return new SimpleRenderer($output, $messageHelper);
+        }
+
+        return new DefaultRenderer($output, $messageHelper);
     }
 
     /**

--- a/src/FileInfo/PhpFileInfo.php
+++ b/src/FileInfo/PhpFileInfo.php
@@ -280,7 +280,7 @@ class PhpFileInfo extends SplFileInfo implements DeprecationCollectionInterface
      */
     public function getClassDeprecation($className)
     {
-        return ($this->hasClassDeprecation($className) ? $this->classDeprecations[$className] : null);
+        return $this->hasClassDeprecation($className) ? $this->classDeprecations[$className] : null;
     }
 
     /**
@@ -324,7 +324,7 @@ class PhpFileInfo extends SplFileInfo implements DeprecationCollectionInterface
      */
     public function getInterfaceDeprecation($interfaceName)
     {
-        return ($this->hasInterfaceDeprecation($interfaceName) ? $this->interfaceDeprecations[$interfaceName] : null);
+        return $this->hasInterfaceDeprecation($interfaceName) ? $this->interfaceDeprecations[$interfaceName] : null;
     }
 
     /**

--- a/src/TypeGuessing/SymbolTable/Resolver/SymfonyResolver.php
+++ b/src/TypeGuessing/SymbolTable/Resolver/SymfonyResolver.php
@@ -121,6 +121,6 @@ class SymfonyResolver implements ResolverInterface
      */
     protected function isController($type)
     {
-        return (substr($type, -10) === 'Controller');
+        return substr($type, -10) === 'Controller';
     }
 }

--- a/src/Violation/Renderer/Console/BaseRenderer.php
+++ b/src/Violation/Renderer/Console/BaseRenderer.php
@@ -43,7 +43,7 @@ abstract class BaseRenderer implements RendererInterface
     /**
      * @param Violation[] $violations
      */
-    protected abstract function printViolations(array $violations);
+    abstract protected function printViolations(array $violations);
 
     /**
      * @param Error[] $errors
@@ -54,7 +54,7 @@ abstract class BaseRenderer implements RendererInterface
             return;
         }
 
-        $this->output->writeln("");
+        $this->output->writeln('');
         $this->output->writeln('<error>Your project contains invalid code:</error>');
         foreach ($errors as $error) {
             $this->output->writeln(

--- a/src/Violation/Renderer/Console/BaseRenderer.php
+++ b/src/Violation/Renderer/Console/BaseRenderer.php
@@ -29,4 +29,40 @@ abstract class BaseRenderer implements RendererInterface
         $this->output = $output;
         $this->messageHelper = $messageHelper;
     }
+
+    /**
+     * @param Violation[] $violations
+     * @param Error[]     $errors
+     */
+    public function renderViolations(array $violations, array $errors)
+    {
+        $this->printViolations($violations);
+        $this->printErrors($errors);
+    }
+
+    /**
+     * @param Violation[] $violations
+     */
+    protected abstract function printViolations(array $violations);
+
+    /**
+     * @param Error[] $errors
+     */
+    protected function printErrors(array $errors)
+    {
+        if (0 === count($errors)) {
+            return;
+        }
+
+        $this->output->writeln("");
+        $this->output->writeln('<error>Your project contains invalid code:</error>');
+        foreach ($errors as $error) {
+            $this->output->writeln(
+                sprintf(
+                    '<error>%s</error>',
+                    $error->getRawMessage()
+                )
+            );
+        }
+    }
 }

--- a/src/Violation/Renderer/Console/BaseRenderer.php
+++ b/src/Violation/Renderer/Console/BaseRenderer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Violation\Renderer\Console;
+
+use PhpParser\Error;
+use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\MessageHelper;
+use SensioLabs\DeprecationDetector\Violation\Renderer\RendererInterface;
+use SensioLabs\DeprecationDetector\Violation\Violation;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class BaseRenderer implements RendererInterface
+{
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * @var MessageHelper
+     */
+    protected $messageHelper;
+
+    /**
+     * @param OutputInterface $output
+     * @param MessageHelper   $messageHelper
+     */
+    public function __construct(OutputInterface $output, MessageHelper $messageHelper)
+    {
+        $this->output = $output;
+        $this->messageHelper = $messageHelper;
+    }
+}

--- a/src/Violation/Renderer/Console/DefaultRenderer.php
+++ b/src/Violation/Renderer/Console/DefaultRenderer.php
@@ -24,18 +24,8 @@ class DefaultRenderer extends BaseRenderer
 
     /**
      * @param Violation[] $violations
-     * @param Error[]     $errors
      */
-    public function renderViolations(array $violations, array $errors)
-    {
-        $this->printViolations($violations);
-        $this->printErrors($errors);
-    }
-
-    /**
-     * @param Violation[] $violations
-     */
-    private function printViolations(array $violations)
+    protected function printViolations(array $violations)
     {
         if (0 === count($violations)) {
             return;
@@ -64,26 +54,6 @@ class DefaultRenderer extends BaseRenderer
         }
 
         $table->render();
-    }
-
-    /**
-     * @param Error[] $errors
-     */
-    private function printErrors(array $errors)
-    {
-        if (0 === count($errors)) {
-            return;
-        }
-
-        $this->output->writeln('<error>Your project contains invalid code:</error>');
-        foreach ($errors as $error) {
-            $this->output->writeln(
-                sprintf(
-                    '<error>%s</error>',
-                    $error->getRawMessage()
-                )
-            );
-        }
     }
 
     /**

--- a/src/Violation/Renderer/Console/DefaultRenderer.php
+++ b/src/Violation/Renderer/Console/DefaultRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SensioLabs\DeprecationDetector\Violation\Renderer;
+namespace SensioLabs\DeprecationDetector\Violation\Renderer\Console;
 
 use PhpParser\Error;
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
@@ -11,26 +11,15 @@ use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ConsoleOutputRenderer implements RendererInterface
+class DefaultRenderer extends BaseRenderer
 {
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
-
-    /**
-     * @var MessageHelper
-     */
-    private $messageHelper;
-
     /**
      * @param OutputInterface $output
      * @param MessageHelper   $messageHelper
      */
     public function __construct(OutputInterface $output, MessageHelper $messageHelper)
     {
-        $this->output = $output;
-        $this->messageHelper = $messageHelper;
+        parent::__construct($output, $messageHelper);
     }
 
     /**

--- a/src/Violation/Renderer/Console/DefaultRenderer.php
+++ b/src/Violation/Renderer/Console/DefaultRenderer.php
@@ -2,7 +2,6 @@
 
 namespace SensioLabs\DeprecationDetector\Violation\Renderer\Console;
 
-use PhpParser\Error;
 use SensioLabs\DeprecationDetector\FileInfo\PhpFileInfo;
 use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\MessageHelper;
 use SensioLabs\DeprecationDetector\Violation\Violation;

--- a/src/Violation/Renderer/Console/SimpleRenderer.php
+++ b/src/Violation/Renderer/Console/SimpleRenderer.php
@@ -20,18 +20,8 @@ class SimpleRenderer extends BaseRenderer
 
     /**
      * @param Violation[] $violations
-     * @param Error[]     $errors
      */
-    public function renderViolations(array $violations, array $errors)
-    {
-        $this->printViolations($violations);
-        $this->printErrors($errors);
-    }
-
-    /**
-     * @param Violation[] $violations
-     */
-    private function printViolations(array $violations)
+    protected function printViolations(array $violations)
     {
         if (0 === count($violations)) {
             return;
@@ -54,16 +44,5 @@ class SimpleRenderer extends BaseRenderer
                 $this->messageHelper->getViolationMessage($violation)
             ));
         }
-    }
-
-    /**
-     * @param Error[] $errors
-     */
-    private function printErrors(array $errors)
-    {
-        if (0 === count($errors)) {
-            return;
-        }
-
     }
 }

--- a/src/Violation/Renderer/Console/SimpleRenderer.php
+++ b/src/Violation/Renderer/Console/SimpleRenderer.php
@@ -2,7 +2,6 @@
 
 namespace SensioLabs\DeprecationDetector\Violation\Renderer\Console;
 
-use PhpParser\Error;
 use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\MessageHelper;
 use SensioLabs\DeprecationDetector\Violation\Violation;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,13 +31,13 @@ class SimpleRenderer extends BaseRenderer
             if ($tmpFile !== $violation->getFile()) {
                 $tmpFile = $violation->getFile();
                 if (0 !== $i) {
-                    $this->output->writeln("");
+                    $this->output->writeln('');
                 }
                 $this->output->writeln($tmpFile->getRelativePathname());
             }
 
             $this->output->writeln(sprintf(
-                "Nr. %d line %d: %s",
+                'Nr. %d line %d: %s',
                 ++$i,
                 $violation->getLine(),
                 $this->messageHelper->getViolationMessage($violation)

--- a/src/Violation/Renderer/Console/SimpleRenderer.php
+++ b/src/Violation/Renderer/Console/SimpleRenderer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SensioLabs\DeprecationDetector\Violation\Renderer\Console;
+
+use PhpParser\Error;
+use SensioLabs\DeprecationDetector\Violation\Renderer\MessageHelper\MessageHelper;
+use SensioLabs\DeprecationDetector\Violation\Violation;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SimpleRenderer extends BaseRenderer
+{
+    /**
+     * @param OutputInterface $output
+     * @param MessageHelper   $messageHelper
+     */
+    public function __construct(OutputInterface $output, MessageHelper $messageHelper)
+    {
+        parent::__construct($output, $messageHelper);
+    }
+
+    /**
+     * @param Violation[] $violations
+     * @param Error[]     $errors
+     */
+    public function renderViolations(array $violations, array $errors)
+    {
+        $this->printViolations($violations);
+        $this->printErrors($errors);
+    }
+
+    /**
+     * @param Violation[] $violations
+     */
+    private function printViolations(array $violations)
+    {
+        if (0 === count($violations)) {
+            return;
+        }
+
+        $tmpFile = null;
+        foreach ($violations as $i => $violation) {
+            if ($tmpFile !== $violation->getFile()) {
+                $tmpFile = $violation->getFile();
+                if (0 !== $i) {
+                    $this->output->writeln("");
+                }
+                $this->output->writeln($tmpFile->getRelativePathname());
+            }
+
+            $this->output->writeln(sprintf(
+                "Nr. %d line %d: %s",
+                ++$i,
+                $violation->getLine(),
+                $this->messageHelper->getViolationMessage($violation)
+            ));
+        }
+    }
+
+    /**
+     * @param Error[] $errors
+     */
+    private function printErrors(array $errors)
+    {
+        if (0 === count($errors)) {
+            return;
+        }
+
+    }
+}

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -16,13 +16,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             '',
             true,
             true,
-            'html.log'
+            'html.log',
+            null
         );
 
         $this->assertInstanceOf('SensioLabs\DeprecationDetector\Configuration\Configuration', $configuration);
     }
 
-    public function testRuleSet()
+    public function testConfiguration()
     {
         $configuration = new Configuration(
             'path/to/rule_set',
@@ -32,7 +33,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             '',
             true,
             true,
-            'html.log'
+            'html.log',
+            null
         );
 
         $this->assertEquals('path/to/rule_set', $configuration->ruleSet());
@@ -43,5 +45,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($configuration->failOnDeprecation());
         $this->assertTrue($configuration->isVerbose());
         $this->assertEquals('html.log', $configuration->logHtml());
+        $this->assertNull(null, $configuration->isSimpleOutput());
     }
 }


### PR DESCRIPTION
```sh
➜  marvin-deprecation-detector git:(feature/simple_output) bin/deprecation-detector check examples examples --output=simple
Checking your application for deprecations - this could take a while ...

Loading RuleSet...

RuleSet loaded.

Parsing files & Searching for deprecations...

Finished searching for deprecations.

Rendering output...

Arguments.php
Nr. 1 line 19: Using deprecated class foo1
Nr. 2 line 13: Using deprecated interface oldInterface by class foo

Controller.php
Nr. 3 line 24: Calling deprecated method BaseController->getEntityManager()
Nr. 4 line 26: Calling deprecated static method BaseController::getEntityManager()
Nr. 5 line 28: Using deprecated function hello()

deprecations.php
Nr. 6 line 48: Using deprecated class foo1
Nr. 7 line 78: Calling deprecated static method foo2::fo()
Nr. 8 line 68: Extending deprecated class foo1 by class foo3
Nr. 9 line 46: Using deprecated class foo1
Nr. 10 line 55: Using deprecated class foo1
Nr. 11 line 74: Overriding deprecated method foo4->bar()

dynamic/CallConstructorFirst.php
Nr. 12 line 19: Using deprecated class OtherClass
Nr. 13 line 12: Calling deprecated method OtherClass->hello()
Nr. 14 line 13: Calling deprecated method OtherClass->world()
Nr. 15 line 16: Using deprecated class OtherClass

dynamic/TrackingArguments.php
Nr. 16 line 7: Calling deprecated method OtherClass->hello()
Nr. 17 line 11: Calling deprecated method OtherClass->world()
Nr. 18 line 5: Using deprecated class OtherClass
Nr. 19 line 9: Using deprecated class OtherClass

dynamic/TrackingVariables.php
Nr. 20 line 14: Using deprecated class OtherClass
Nr. 21 line 16: Calling deprecated method OtherClass->hello()
Nr. 22 line 18: Calling deprecated static method OtherClass::world()
Nr. 23 line 20: Calling deprecated static method OtherClass::world()
Nr. 24 line 8: Overriding deprecated method SomeClass->sayHello()

FormType.php
Nr. 25 line 55: Calling deprecated static method ExampleForm\FormTypeInterface::setDefaultOptions()
Nr. 26 line 26: Using deprecated interface OptionsResolverInterface
Nr. 27 line 34: Using deprecated interface OptionsResolverInterface
Nr. 28 line 51: Using deprecated interface OptionsResolverInterface
Nr. 29 line 34: Overriding deprecated method ExampleForm\AbstractType->setDefaultOptions()
Nr. 30 line 51: Overriding deprecated method SomeType\CustomFormType->setDefaultOptions()

LanguageDeprecations.php
Nr. 31 line 12: Using deprecated function call_user_method()
Nr. 32 line 5: Using deprecated language feature PHP4 constructor
Nr. 33 line 10: Using deprecated language feature assign by reference(&=)
Nr. 34 line 13: Using deprecated language feature call-time pass-by-reference
Finished rendering output.

34 deprecations found.
```