### PR TITLE
Remove unbound version constraint for PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9",
+        "php": "^5.3.9 || ^7.0",
         "nikic/php-parser": "^1.3",
         "symfony/console": "^2.6 || ^3.0",
         "symfony/finder": "^2.6 || ^3.0",


### PR DESCRIPTION
Ref: https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md