### PR TITLE
travis: add PHP 7.1, drop unused allowed fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
 language: php
 
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+
 sudo: false
 
 cache:
     directories:
         - $HOME/.composer/cache/files
-
-matrix:
-    include:
-        - php: 5.5
-        - php: 5.6
-        - php: 7
-    allow_failures:
-        - php: 7
-    fast_finish: true
 
 install:
     - composer install --prefer-dist


### PR DESCRIPTION
PHP 7.0 passes for a long time, so there is no need for allowed and fast failures